### PR TITLE
-1 state filter

### DIFF
--- a/src/Heatmap.js
+++ b/src/Heatmap.js
@@ -464,6 +464,7 @@ async function getBinsForID(analysis, id) {
     .size(50000)
     .filter("exists", "copy")
     .filter("term", "cell_id", id)
+    .filter("range", "state", { gte: 0 })
     .build();
 
   const results = await client.search({

--- a/src/Heatmap.js
+++ b/src/Heatmap.js
@@ -192,6 +192,7 @@ export const resolvers = {
       const segsQuery = bodybuilder()
         .size(50000)
         .filter("terms", "cell_id", ids)
+        .filter("range", "state", { gte: 0 })
         .build();
 
       const segResults = await client.search({
@@ -199,9 +200,10 @@ export const resolvers = {
         body: segsQuery,
       });
 
+      const minBP = Math.floor(0.1 * bpRatio);
       const allSegs = segResults.body.hits.hits
         .map((seg) => seg["_source"])
-        .filter((seg) => Math.floor((seg.end - seg.start + 1) / bpRatio));
+        .filter((seg) => seg.end - seg.start + 1 > minBP);
 
       return cells.map((cell) => ({
         ...cell,


### PR DESCRIPTION
For cases where you want to mask parts of the chromosome while retaining the original length of it -- in these cases, if you remove from the ends of chromosomes, the chromosome axis shrinks. To subvert this, one can load segments with state of -1 to indicate regions you want to keep on the axis but not show -- and to accommodate this, the graphQL layer now filters out those segments and bins from the data that is returned for specific cells.